### PR TITLE
fix: change Command property to GetCommand method

### DIFF
--- a/src/DevantlerTech.ArgoCDCLI/ArgoCD.cs
+++ b/src/DevantlerTech.ArgoCDCLI/ArgoCD.cs
@@ -11,28 +11,25 @@ public static class ArgoCD
   /// <summary>
   /// The argocd CLI command.
   /// </summary>
-  static Command Command
+  public static Command GetCommand()
   {
-    get
-    {
-      string binaryName = "argocd";
-      string? pathEnv = Environment.GetEnvironmentVariable("PATH");
+    string binaryName = "argocd";
+    string? pathEnv = Environment.GetEnvironmentVariable("PATH");
 
-      if (!string.IsNullOrEmpty(pathEnv))
+    if (!string.IsNullOrEmpty(pathEnv))
+    {
+      string[] paths = pathEnv.Split(Path.PathSeparator);
+      foreach (string dir in paths)
       {
-        string[] paths = pathEnv.Split(Path.PathSeparator);
-        foreach (string dir in paths)
+        string fullPath = Path.Combine(dir, binaryName);
+        if (File.Exists(fullPath))
         {
-          string fullPath = Path.Combine(dir, binaryName);
-          if (File.Exists(fullPath))
-          {
-            return Cli.Wrap(fullPath);
-          }
+          return Cli.Wrap(fullPath);
         }
       }
-
-      throw new FileNotFoundException($"The '{binaryName}' CLI was not found in PATH.");
     }
+
+    throw new FileNotFoundException($"The '{binaryName}' CLI was not found in PATH.");
   }
 
   /// <summary>
@@ -54,7 +51,7 @@ public static class ArgoCD
     using var stdInConsole = input ? Stream.Null : Console.OpenStandardInput();
     using var stdOutConsole = silent ? Stream.Null : Console.OpenStandardOutput();
     using var stdErrConsole = silent ? Stream.Null : Console.OpenStandardError();
-    var command = Command.WithArguments(arguments)
+    var command = GetCommand().WithArguments(arguments)
       .WithValidation(validation)
       .WithStandardInputPipe(PipeSource.FromStream(stdInConsole))
       .WithStandardOutputPipe(PipeTarget.ToStream(stdOutConsole))


### PR DESCRIPTION
Replace the static Command property with a GetCommand method to improve clarity and functionality in retrieving the argocd CLI command.